### PR TITLE
enable venmo business profiles

### DIFF
--- a/venmo/transfer_venmo.json
+++ b/venmo/transfer_venmo.json
@@ -69,7 +69,7 @@
     },
     {
       "type": "regex",
-      "value": "\"subType\":\"none\""
+      "value": "\"subType\":\"(none|business_profile)\""
     }
   ],
   "responseRedactions": [


### PR DESCRIPTION
Enables `subType: business_profile` which is if seller is business account. `subtype: payment_protected` is still not allowed so users cannot turn on purchase protection 