### PR TITLE
feat: Packagify and publish as an npm package @zkp2p/providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,51 @@
 
 This repo houses the JSON providers used in ZKP2P PeerAuth Extension and ZKP2P React Native SDK. ZKP2P is live in production at [zkp2p.xyz](https://zkp2p.xyz/). PeerAuth is a browser extension that allows you to authenticate internet data in a privacy preserving way using web proofs / zkTLS
 
+## Package Usage (npm)
+
+This package is data-only. Consumers import the JSON templates directly via deep import paths, or read the included manifest.
+
+Install:
+
+```bash
+npm install @zkp2p/providers
+# or
+yarn add @zkp2p/providers
+```
+
+CommonJS (Node):
+
+```js
+const zelle = require('@zkp2p/providers/citi/transfer_zelle.json');
+console.log(zelle.actionType);
+```
+
+ESM (Node with import assertions):
+
+```js
+import zelle from '@zkp2p/providers/citi/transfer_zelle.json' assert { type: 'json' };
+console.log(zelle.actionType);
+```
+
+Manifest (providers.json):
+
+```js
+// CJS
+const manifest = require('@zkp2p/providers/providers.json');
+for (const p of manifest.providers) console.log(p.id, p.files);
+
+// ESM
+import manifest from '@zkp2p/providers/providers.json' assert { type: 'json' };
+```
+
+Notes:
+- No runtime code is shipped; only JSON and docs.
+- Deep imports like `@zkp2p/providers/<provider>/<file>.json` are stable entry points.
+- Bundlers (Webpack/Vite) support JSON imports by default.
+
+
 ## Developer Quickstart
+Note: The npm package is data-only. The local dev server described here is for development/testing in this repo and is not included in the published package.
 To get started building a new provider, you will need to setup a local version of 
 1. Clone the repo
 2. Run `yarn install` and `yarn start`. App is hosted on [http://localhost:8080](http://localhost:8080)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
-  "name": "zkp2p-providers",
+  "name": "@zkp2p/providers",
   "version": "1.0.0",
-  "description": "Host provider JSON templates for ZKP2P",
-  "main": "index.js",
+  "description": "Provider JSON templates for ZKP2P (data-only)",
   "scripts": {
     "start": "node index.js"
   },
-  "dependencies": {
+  "files": [
+    "**/*.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2"
   },

--- a/providers.json
+++ b/providers.json
@@ -1,0 +1,22 @@
+{
+  "providers": [
+    { "id": "bankofamerica", "files": ["bankofamerica/transfer_zelle.json"] },
+    { "id": "cashapp", "files": ["cashapp/transfer_cashapp.json"] },
+    { "id": "chase", "files": ["chase/transfer_zelle.json"] },
+    { "id": "citi", "files": ["citi/transfer_zelle.json"] },
+    { "id": "idfc", "files": ["idfc/transfer_idfc.json"] },
+    { "id": "luxon", "files": ["luxon/transfer_luxon.json"] },
+    { "id": "mercadopago", "files": [
+      "mercadopago/transfer_mercado_pago.json",
+      "mercadopago/transfer_mercadopago.json"
+    ] },
+    { "id": "monzo", "files": ["monzo/transfer_monzo.json"] },
+    { "id": "paypal", "files": ["paypal/transfer_paypal.json"] },
+    { "id": "revolut", "files": ["revolut/transfer_revolut.json"] },
+    { "id": "royalbankcanada", "files": ["royalbankcanada/transfer_interac.json"] },
+    { "id": "usbank", "files": ["usbank/transfer_zelle.json"] },
+    { "id": "venmo", "files": ["venmo/transfer_venmo.json"] },
+    { "id": "wise", "files": ["wise/transfer_wise.json"] }
+  ]
+}
+


### PR DESCRIPTION
### Published package

- [@zkp2p/providers: v1.0.0](https://www.npmjs.com/package/@zkp2p/providers?activeTab=readme)

### Changes
- Rename package to @zkp2p/providers; set publishConfig.access=public
- Make package data-only: add files whitelist (JSON, README, LICENSE) and sideEffects: false
- Move express/cors to devDependencies; keep local dev server for repo-only use
- Add providers.json manifest enumerating available provider templates
- Update README with install/usage for @zkp2p/providers (CJS/ESM deep imports, manifest)