### PR TITLE
feat(register) add Venmo registration provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.4",
+  "version": "7.8.5",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/providers.json
+++ b/providers.json
@@ -14,7 +14,7 @@
     { "id": "revolut", "files": ["revolut/transfer_revolut.json"] },
     { "id": "royalbankcanada", "files": ["royalbankcanada/transfer_interac.json"] },
     { "id": "usbank", "files": ["usbank/transfer_zelle.json"] },
-    { "id": "venmo", "files": ["venmo/transfer_venmo.json"] },
+    { "id": "venmo", "files": ["venmo/transfer_venmo.json", "venmo/register_venmo.json"] },
     { "id": "wise", "files": ["wise/transfer_wise.json", "wise/register_wise.json"] },
     { "id": "n26", "files": ["n26/transfer_n26.json"] },
     { "id": "alipay", "files": ["alipay/transfer_alipay.json", "alipay/register_alipay.json"] },

--- a/venmo/register_venmo.json
+++ b/venmo/register_venmo.json
@@ -20,8 +20,8 @@
     },
     "proofMetadataSelectors": [
       {
-        "type": "regex",
-        "value": "\"id\":\"([0-9]+)\",\"displayName\":\"you\""
+        "type": "jsonPath",
+        "value": "$.stories[{{INDEX}}].paymentId"
       }
     ]
   },

--- a/venmo/register_venmo.json
+++ b/venmo/register_venmo.json
@@ -1,0 +1,77 @@
+{
+  "actionType": "register_venmo",
+  "proofEngine": "reclaim",
+  "authLink": "https://account.venmo.com/?feed=mine",
+  "url": "https://account.venmo.com/api/stories?feedType=me&externalId={{SENDER_ID}}",
+  "method": "GET",
+  "body": "",
+  "metadata": {
+    "platform": "venmo",
+    "urlRegex": "https://account.venmo.com/api/stories\\?feedType=me&externalId=\\S+",
+    "method": "GET",
+    "fallbackUrlRegex": "",
+    "fallbackMethod": "",
+    "preprocessRegex": "",
+    "transactionsExtraction": {
+      "transactionJsonPathListSelector": "$.stories",
+      "transactionJsonPathSelectors": {
+        "senderId": "$.title.sender.id"
+      }
+    },
+    "proofMetadataSelectors": [
+      {
+        "type": "regex",
+        "value": "\"id\":\"([0-9]+)\",\"displayName\":\"you\""
+      }
+    ]
+  },
+  "paramNames": [
+    "SENDER_ID"
+  ],
+  "paramSelectors": [
+    {
+      "type": "regex",
+      "value": "externalId=([0-9]+)",
+      "source": "url"
+    }
+  ],
+  "skipRequestHeaders": [],
+  "secretHeaders": [
+    "Cookie"
+  ],
+  "responseMatches": [
+    {
+      "type": "regex",
+      "value": "\"paymentId\":\"[^\"]+\""
+    }
+  ],
+  "responseRedactions": [
+    {
+      "jsonPath": "$.stories[{{INDEX}}].paymentId",
+      "xPath": ""
+    }
+  ],
+  "mobile": {
+    "includeAdditionalCookieDomains": [],
+    "additionalClientOptions": {
+      "cipherSuites": [
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+      ]
+    },
+    "useExternalAction": true,
+    "external": {
+      "actionLink": "venmo://paycharge?txn=pay&recipients={{RECIPIENT_ID}}&note=Thx&amount={{AMOUNT}}",
+      "appStoreLink": "https://apps.apple.com/us/app/venmo/id351727428",
+      "playStoreLink": "https://play.google.com/store/apps/details?id=com.venmo"
+    },
+    "login": {
+      "usernameSelector": "#email, input[name=\"login_email\"], input[name=\"username\"], input[type=\"email\"], input[data-testid=\"text-input-username\"]",
+      "passwordSelector": "#password, input[name=\"login_password\"][type=\"password\"][data-testid=\"text-input-password\"]",
+      "nextSelector": "#btnNext, button[data-testid=\"button-next\"], button.next_button[type=\"submit\"]",
+      "submitSelector": "#btnLogin, button[data-testid=\"button-submit\"][type=\"submit\"], button.login_button[type=\"submit\"]",
+      "revealTimeoutMs": 5000
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a new `register_venmo` provider backed by the Venmo stories endpoint
- keep auth-time extracted metadata limited to sender ID only
- derive the request sender ID from the request URL instead of the selected row
- use direct JSONPath proof metadata on the selected row's `paymentId`
- use a minimal per-transaction `paymentId` match/redaction pair to satisfy the current proof validator requirement for non-empty `responseMatches`
- register the new provider in `providers.json` and bump `@zkp2p/providers` to `7.8.5`

## Why

The Venmo registration flow needs an account-binding proof, not a transfer proof. The new provider mirrors the existing Venmo request shape while removing transfer-specific auth metadata exposure so the registration flow only extracts the sender ID from the list response while the proof metadata comes from a stable selected-row payment identifier.

The current proof runtime rejects providers with an empty `responseMatches` array, so this PR keeps a single unused placeholder field. The placeholder is now tied to a row-specific transaction identifier instead of a generic subtype field.

## Validation

- `jq empty package.json providers.json venmo/register_venmo.json`
- `curl -sf http://localhost:8080/venmo/register_venmo.json | jq '.actionType, .responseMatches, .responseRedactions'`
- manual provider validation against the live Venmo/developer flow confirmed successful proof generation during implementation; the final follow-up changes keep the placeholder field on `paymentId` and switch proof metadata to JSONPath on that same field
