### PR TITLE
fix(n26): transaction type regex matching

### DIFF
--- a/n26/transfer_n26.json
+++ b/n26/transfer_n26.json
@@ -94,6 +94,10 @@
     {
       "type": "regex",
       "value": "\"iban\":\"(?<recipientId>[A-Z]{2}[A-Z0-9]+)\""
+    },
+    {
+      "type": "regex",
+      "value": "\"value\":\"(?:Instant bank transfer|Echtzeit\u00fcberweisung|Virement instantan\u00e9|Transferencia inmediata|Bonifico istantaneo)\""
     }
   ],
   "responseRedactions": [
@@ -115,6 +119,10 @@
     },
     {
       "jsonPath": "$.data.transaction.containers[1].body[1].action.params.iban",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.transaction.containers[*].body[?(@.id==\"transaction_type_component\")].value",
       "xPath": ""
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.5",
+  "version": "7.8.6",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
## Summary
- Hard-cut `n26/transfer_n26.json` to instant bank transfers by requiring `transaction_type_component.value` to match the localized instant-transfer labels used by N26
- Accept the following localized instant-transfer values: `Instant bank transfer`, `Echtzeitüberweisung`, `Virement instantané`, `Transferencia inmediata`, and `Bonifico istantaneo`
- Bind the proof to the transaction type through an id-scoped JSONPath redaction while revealing only the `value` field needed by the matcher
- Leave the extracted proof fields unchanged (`amount`, `currency`, `date`, `paymentId`, `recipientId`), so the proof shape stays the same while the provider hash changes

## Evidence
- `instant.json` passes the new instant-transfer gate
- `normal.json` fails because `transaction_type_component.value == "Bank transfer"`
- `n26_new.json` also fails because `transaction_type_component.value == "Bank transfer"`
- The localized matcher regex compiles and matches all five accepted instant-transfer strings

## Test plan
- [x] Verified the matcher against the redacted transcript for `instant.json`
- [x] Verified the matcher rejects `normal.json`
- [x] Verified the matcher rejects `n26_new.json`
- [x] Verified the localized regex matches all accepted language variants
- [x] End-to-end test on developer.peer.xyz with PeerAuth
