### PR TITLE
feat(paypal): Add PayPal register and business transfer providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.6",
+  "version": "7.8.7",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/paypal/register_paypal.json
+++ b/paypal/register_paypal.json
@@ -1,0 +1,89 @@
+{
+  "actionType": "register_paypal",
+  "proofEngine": "reclaim",
+  "authLink": "https://www.paypal.com/myaccount/profile/",
+  "url": "https://www.paypal.com/myaccount/profile/home/api/user",
+  "method": "GET",
+  "body": "",
+  "metadata": {
+    "platform": "paypal",
+    "urlRegex": "^https://www.paypal.com/myaccount/profile/home/api/user\\?locale\\.x=[^&]+&country\\.x=[A-Z]{2}(?:&.*)?$",
+    "method": "GET",
+    "fallbackUrlRegex": "",
+    "fallbackMethod": "",
+    "preprocessRegex": "",
+    "transactionsExtraction": {
+      "transactionJsonPathListSelector": "",
+      "transactionJsonPathSelectors": {
+        "email": "$.data.emails.emailPreference.email",
+        "paypalMeLink": "$.data.paypalMe.link"
+      }
+    },
+    "proofMetadataSelectors": [
+      {
+        "type": "jsonPath",
+        "value": "$.data.emails.emailPreference.email"
+      },
+      {
+        "type": "jsonPath",
+        "value": "$.data.paypalMe.link"
+      }
+    ]
+  },
+  "paramNames": [],
+  "paramSelectors": [],
+  "skipRequestHeaders": [
+    "Cookie",
+    "Accept-Encoding"
+  ],
+  "secretHeaders": [
+    "Cookie"
+  ],
+  "responseMatches": [
+    {
+      "type": "regex",
+      "value": "(?<email>[^\"\\s]*@[^\"\\s]*)"
+    },
+    {
+      "type": "regex",
+      "value": "paypal\\.me\\/(?<paypalUsername>[^\"\\/\\s]+)"
+    }
+  ],
+  "responseRedactions": [
+    {
+      "jsonPath": "$.data.emails.emailPreference.email",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.paypalMe.link",
+      "xPath": ""
+    }
+  ],
+  "mobile": {
+    "includeAdditionalCookieDomains": [],
+    "additionalClientOptions": {
+      "cipherSuites": [
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+      ]
+    },
+    "userAgent": {
+      "android": "Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.207 Mobile Safari/537.36",
+      "ios": "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15"
+    },
+    "useExternalAction": true,
+    "external": {
+      "actionLink": "paypal://",
+      "appStoreLink": "https://apps.apple.com/us/app/paypal-pay-send-save/id283646709",
+      "playStoreLink": "https://play.google.com/store/apps/details?id=com.paypal.android.p2pmobile&hl=en_US"
+    },
+    "login": {
+      "usernameSelector": "#email, input[name=\"login_email\"][type=\"email\"]",
+      "passwordSelector": "#password, input[name=\"login_password\"][type=\"password\"]",
+      "nextSelector": "#btnNext, button[name=\"btnNext\"][type=\"submit\"]",
+      "submitSelector": "#btnLogin, button[name=\"btnLogin\"], button.actionContinue[value=\"Login\"], button[value=\"Login\"][type=\"submit\"]",
+      "revealTimeoutMs": 5000
+    }
+  }
+}

--- a/paypal/transfer_business_paypal.json
+++ b/paypal/transfer_business_paypal.json
@@ -1,0 +1,116 @@
+{
+  "actionType": "transfer_business_paypal",
+  "proofEngine": "reclaim",
+  "authLink": "https://www.paypal.com/mep/unifiedtransactions/?filter=0&query=",
+  "url": "https://www.paypal.com/activity/api/payment/{{PAYMENT_ID}}",
+  "method": "GET",
+  "body": "",
+  "metadata": {
+    "platform": "paypal",
+    "urlRegex": "^https://www.paypal.com/unifiedtransactions/v1/transactions$",
+    "method": "POST",
+    "fallbackUrlRegex": "",
+    "fallbackMethod": "",
+    "preprocessRegex": "",
+    "transactionsExtraction": {
+      "transactionJsonPathListSelector": "$.transactions",
+      "transactionJsonPathSelectors": {
+        "recipient": "$.name",
+        "amount": "$.gross",
+        "date": "$.createTime",
+        "paymentId": "$.id",
+        "currency": "$.currency",
+        "type": "$.description"
+      }
+    },
+    "proofMetadataSelectors": [
+      {
+        "type": "jsonPath",
+        "value": "$.transactions[{{INDEX}}].id"
+      }
+    ]
+  },
+  "paramNames": [
+    "PAYMENT_ID"
+  ],
+  "paramSelectors": [
+    {
+      "type": "jsonPath",
+      "value": "$.transactions[{{INDEX}}].id"
+    }
+  ],
+  "skipRequestHeaders": [
+    "Cookie",
+    "Accept-Encoding"
+  ],
+  "secretHeaders": [
+    "Cookie"
+  ],
+  "responseMatches": [
+    {
+      "type": "regex",
+      "value": "(?<recvId>[^\"\\s]*@[^\"\\s]*)"
+    },
+    {
+      "type": "regex",
+      "value": "\\$(?<amt>[0-9.]+)"
+    },
+    {
+      "type": "regex",
+      "value": "\"grossAmt\":\"[^\\\"]*[0-9.]+[^A-Z]*(?<curr>[A-Z]+)"
+    },
+    {
+      "type": "regex",
+      "value": "\"paymentStatusActual\":\"(?<status>[^\"]+)"
+    },
+    {
+      "type": "regex",
+      "value": "(?<date>[A-Z][a-z]+ [0-9]{1,2}, [0-9]{4}[^\"]*)"
+    }
+  ],
+  "responseRedactions": [
+    {
+      "jsonPath": "$.data.data.data.NameEmailPaidBy.CounterPartyContactModelData.email",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.data.data.TDHeader.grossAmt",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.data.data.TDHeader.paymentStatusActual",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.data.data.TDHeader.date",
+      "xPath": ""
+    }
+  ],
+  "mobile": {
+    "includeAdditionalCookieDomains": [],
+    "additionalClientOptions": {
+      "cipherSuites": [
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+      ]
+    },
+    "userAgent": {
+      "android": "Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.207 Mobile Safari/537.36",
+      "ios": "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15"
+    },
+    "useExternalAction": true,
+    "external": {
+      "actionLink": "paypal://",
+      "appStoreLink": "https://apps.apple.com/us/app/paypal-pay-send-save/id283646709",
+      "playStoreLink": "https://play.google.com/store/apps/details?id=com.paypal.android.p2pmobile&hl=en_US"
+    },
+    "login": {
+      "usernameSelector": "#email, input[name=\"login_email\"][type=\"email\"]",
+      "passwordSelector": "#password, input[name=\"login_password\"][type=\"password\"]",
+      "nextSelector": "#btnNext, button[name=\"btnNext\"][type=\"submit\"]",
+      "submitSelector": "#btnLogin, button[name=\"btnLogin\"], button.actionContinue[value=\"Login\"], button[value=\"Login\"][type=\"submit\"]",
+      "revealTimeoutMs": 5000
+    }
+  }
+}

--- a/providers.json
+++ b/providers.json
@@ -10,7 +10,7 @@
     { "id": "mercadopago", "files": ["mercadopago/transfer_mercadopago.json"] },
     { "id": "mercury", "files": ["mercury/mercury-wires.json"] },
     { "id": "monzo", "files": ["monzo/transfer_monzo.json"] },
-    { "id": "paypal", "files": ["paypal/transfer_paypal.json"] },
+    { "id": "paypal", "files": ["paypal/transfer_paypal.json", "paypal/register_paypal.json"] },
     { "id": "revolut", "files": ["revolut/transfer_revolut.json"] },
     { "id": "royalbankcanada", "files": ["royalbankcanada/transfer_interac.json"] },
     { "id": "usbank", "files": ["usbank/transfer_zelle.json"] },

--- a/providers.json
+++ b/providers.json
@@ -10,7 +10,7 @@
     { "id": "mercadopago", "files": ["mercadopago/transfer_mercadopago.json"] },
     { "id": "mercury", "files": ["mercury/mercury-wires.json"] },
     { "id": "monzo", "files": ["monzo/transfer_monzo.json"] },
-    { "id": "paypal", "files": ["paypal/transfer_paypal.json", "paypal/register_paypal.json"] },
+    { "id": "paypal", "files": ["paypal/transfer_paypal.json", "paypal/register_paypal.json", "paypal/transfer_business_paypal.json"] },
     { "id": "revolut", "files": ["revolut/transfer_revolut.json"] },
     { "id": "royalbankcanada", "files": ["royalbankcanada/transfer_interac.json"] },
     { "id": "usbank", "files": ["usbank/transfer_zelle.json"] },


### PR DESCRIPTION
## Summary
- add `paypal/register_paypal.json` for PayPal profile registration proofs
- extract the primary email and PayPal.Me username from the PayPal profile response with minimal redactions
- add `paypal/transfer_business_paypal.json` for PayPal business transfer proofs using the unified transactions activity flow
- extract the transaction id from the business activity list and prove recipient email, amount, currency, status, and date from the PayPal payment detail response
- register both PayPal provider templates in `providers.json`
- bump the package version to `7.8.7`

## Implementation Notes
- `register_paypal` uses the PayPal profile API and proves the email plus the PayPal.Me handle derived from the returned link
- `transfer_business_paypal` uses PayPal business unified transactions metadata and the payment detail endpoint for the notarized proof
- the business transfer proof is configured under the PayPal metadata group, so the developer flow should use `Payment Platform = paypal` and `Metadata Group = paypal`
- business transfer regexes were relaxed to match value shapes while still keeping enough field context to avoid cross-field extraction collisions in the PayPal receipt payload

## Testing
- `jq . paypal/register_paypal.json`
- `jq . paypal/transfer_business_paypal.json`
- `curl -sf http://localhost:8080/paypal/register_paypal.json | jq ...`
- `curl -sf http://localhost:8080/paypal/transfer_business_paypal.json | jq ...`
- live `developer.peer.xyz` `AUTHENTICATE` + `PROVE` for `register_paypal`
- live `developer.peer.xyz` `AUTHENTICATE` + `PROVE` for `transfer_business_paypal`