### PR TITLE
fix(n26): Revert N26 instant transfer restriction

### DIFF
--- a/n26/transfer_n26.json
+++ b/n26/transfer_n26.json
@@ -94,10 +94,6 @@
     {
       "type": "regex",
       "value": "\"iban\":\"(?<recipientId>[A-Z]{2}[A-Z0-9]+)\""
-    },
-    {
-      "type": "regex",
-      "value": "\"value\":\"(?:Instant bank transfer|Echtzeit\u00fcberweisung|Virement instantan\u00e9|Transferencia inmediata|Bonifico istantaneo)\""
     }
   ],
   "responseRedactions": [
@@ -119,10 +115,6 @@
     },
     {
       "jsonPath": "$.data.transaction.containers[1].body[1].action.params.iban",
-      "xPath": ""
-    },
-    {
-      "jsonPath": "$.data.transaction.containers[*].body[?(@.id==\"transaction_type_component\")].value",
       "xPath": ""
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.8",
+  "version": "7.8.9",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
## Summary
- Reverts `6231d35` ("fix(n26): hard-cut transfer proof to instant transfers")
- Removes the instant transfer type check from the N26 transfer proof, allowing all transfer types again

## Test plan
- [ ] Verify N26 transfer proofs work for both instant and standard transfers

🤖 Generated with [Claude Code](https://claude.com/claude-code)