### PR TITLE
Add PayPal business payment type parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.9",
+  "version": "7.8.10",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/paypal/transfer_business_paypal.json
+++ b/paypal/transfer_business_paypal.json
@@ -53,7 +53,7 @@
     },
     {
       "type": "regex",
-      "value": "\"paymentType\":\"(?<isPersonal>Friends and Family|Goods and Services)\""
+      "value": "\"paymentType\":\"(?<isPersonal>[^\"]+)\""
     },
     {
       "type": "regex",

--- a/paypal/transfer_business_paypal.json
+++ b/paypal/transfer_business_paypal.json
@@ -53,6 +53,10 @@
     },
     {
       "type": "regex",
+      "value": "\"paymentType\":\"(?<isPersonal>Friends and Family|Goods and Services)\""
+    },
+    {
+      "type": "regex",
       "value": "\\$(?<amt>[0-9.]+)"
     },
     {
@@ -79,6 +83,10 @@
     },
     {
       "jsonPath": "$.data.data.data.TDHeader.paymentStatusActual",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.data.data.TDHeader.paymentType",
       "xPath": ""
     },
     {


### PR DESCRIPTION
## Summary
- Add a regex matcher for PayPal `paymentType` values in business transfer receipts
- Map `TDHeader.paymentType` into the extracted field set

## Testing
- Not run (not requested)