### PR TITLE
feat(paypal): Update PayPal metadata auth link

### DIFF
--- a/paypal/transfer_paypal.json
+++ b/paypal/transfer_paypal.json
@@ -1,13 +1,16 @@
 {
   "actionType": "transfer_paypal",
   "proofEngine": "reclaim",
-  "authLink": "https://www.paypal.com/myaccount/activities/filter/?q=ZnJlZV90ZXh0X3NlYXJjaD0mc3RhcnRfZGF0ZT0yMDI1LTAxLTAxJmVuZF9kYXRlPTIwMzAtMTItMzEmdHlwZT0mc3RhdHVzPSZjdXJyZW5jeT0mZmlsdGVyX2lkPSZpc3N1YW5jZV9wcm9kdWN0X25hbWU9JmFzc2V0X25hbWVzPSZhc3NldF9zeW1ib2xzPQ",
+  "authLink": "https://www.paypal.com/myaccount/activities/",
   "url": "https://www.paypal.com/myaccount/activities/details/inline/{{PAYMENT_ID}}",
   "method": "GET",
   "body": "",
   "metadata": {
+    "metadataUrl": "https://www.paypal.com/myaccount/activities/filter/?q=ZnJlZV90ZXh0X3NlYXJjaD0mc3RhcnRfZGF0ZT0yMDI1LTAxLTAxJmVuZF9kYXRlPTIwMzAtMTItMzEmdHlwZT0mc3RhdHVzPSZjdXJyZW5jeT0mZmlsdGVyX2lkPSZpc3N1YW5jZV9wcm9kdWN0X25hbWU9JmFzc2V0X25hbWVzPSZhc3NldF9zeW1ib2xzPQ",
+    "metadataUrlMethod": "GET",
+    "metadataUrlBody": "",
     "platform": "paypal",
-    "urlRegex": "^https://www.paypal.com/myaccount/activities/filter/\\?q=.*$",
+    "urlRegex": "https://www.paypal.com/myaccount",
     "method": "GET",
     "fallbackUrlRegex": "",
     "fallbackMethod": "",


### PR DESCRIPTION
## Summary
- Point PayPal authLink at the main activities page
- Move the filter URL into metadataUrl for metadata fetching
- Relax the urlRegex to match the broader PayPal account path

## Testing
- Not run (not requested)