### PR TITLE
Docs: Update README. Add warnings and rebrand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Peer Provider Templates
 
-This repo houses the JSON providers used in ZKP2P PeerAuth Extension and ZKP2P React Native SDK. ZKP2P is live in production at [zkp2p.xyz](https://zkp2p.xyz/). PeerAuth is a browser extension that allows you to authenticate internet data in a privacy preserving way using web proofs / zkTLS
+This repo houses the JSON providers used in Peer Extension and Peer React Native SDK. Peer is live in production at [peer.xyz](https://peer.xyz/). Peer Extension is a browser extension that allows you to authenticate internet data in a privacy preserving way using web proofs / zkTLS
 
 ## Package Usage (npm)
 
@@ -50,17 +50,17 @@ Note: The npm package is data-only. The local dev server described here is for d
 To get started building a new provider, you will need to setup a local version of 
 1. Clone the repo
 2. Run `yarn install` and `yarn start`. App is hosted on [http://localhost:8080](http://localhost:8080)
-3. Install the [PeerAuth extension](https://chromewebstore.google.com/detail/peerauth-authenticate-and/ijpgccednehjpeclfcllnjjcmiohdjih) in your browser
+3. Install the [Peer extension](https://chromewebstore.google.com/detail/peer-funding-wallet/ijpgccednehjpeclfcllnjjcmiohdjih) in your browser
 3. Create a new directory and JSON file and add the necessary provider data for your integration
 4. Test your integration by going to the [Peer Developer Portal](https://developer.peer.xyz/)
-5. Click on Open Settings on the page. This will open the PeerAuth extension, set Providers Base URL to `http://localhost:8080/` (Note the "/" at the end, it is required). Any changes to your JSON will now be reflected in the extension and developer app
+5. Click on Open Settings on the page. This will open the Peer extension, set Providers Base URL to `http://localhost:8080/` (Note the "/" at the end, it is required). Any changes to your JSON will now be reflected in the extension and developer app
 6. In the Peer Developer Portal, update the inputs with the right path to your integration: "ActionType" refers to platform_name (i.e.: Zelle, Venmo...) and Payment Platform refers to provider_name (i.e.: Chase, Truist ...)
 7. Click Authenticate to extract metadata
 8. If successful, proceed to Prove a specific transaction
 
 ## Provider Configuration Guide
 
-This guide explains how to create and configure provider templates for the ZKP2P PeerAuth extension. Provider configurations define how to extract and verify data from various platforms.
+This guide explains how to create and configure provider templates for the Peer extension. Provider configurations define how to extract and verify data from various platforms.
 
 ### Table of Contents
 - [Getting Started](#getting-started)
@@ -71,7 +71,7 @@ This guide explains how to create and configure provider templates for the ZKP2P
 - [Common Issues](#common-issues)
 
 ### Getting Started
-1. Inspect network tab in Dev Tools after logging into your payment website. Or turn on Intercepted Requests in ZKP2P sidebar
+1. Inspect network tab in Dev Tools after logging into your payment website. Or turn on Intercepted Requests in Peer sidebar
 2. Find a request that contains amount, timestamp / date, recipient ID at a minimum. Look for additional params such as status (to see if payment finalized), currency (if platform supports more than 1 currency)
 3. A tip is to look for where the transactions page is. Sometimes the transactions are expandable so you can log those too
 4. Based on the request, populate the template.
@@ -338,7 +338,7 @@ The `source` field in `paramSelectors` specifies where to extract the parameter 
 
 #### `mobile` (optional)
 - **Type**: `object`
-- **Description**: Special configurations for the ZKP2P mobile SDK. The mobile configuration supports both internal (WebView) and external (native app) actions.
+- **Description**: Special configurations for the Peer mobile SDK. The mobile configuration supports both internal (WebView) and external (native app) actions.
 
 ```json
 "mobile": {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZKP2P Provider Templates
+# Peer Provider Templates
 
 This repo houses the JSON providers used in ZKP2P PeerAuth Extension and ZKP2P React Native SDK. ZKP2P is live in production at [zkp2p.xyz](https://zkp2p.xyz/). PeerAuth is a browser extension that allows you to authenticate internet data in a privacy preserving way using web proofs / zkTLS
 
@@ -52,9 +52,9 @@ To get started building a new provider, you will need to setup a local version o
 2. Run `yarn install` and `yarn start`. App is hosted on [http://localhost:8080](http://localhost:8080)
 3. Install the [PeerAuth extension](https://chromewebstore.google.com/detail/peerauth-authenticate-and/ijpgccednehjpeclfcllnjjcmiohdjih) in your browser
 3. Create a new directory and JSON file and add the necessary provider data for your integration
-4. Test your integration by going to [developer.zkp2p.xyz](https://developer.zkp2p.xyz/)
-5. Click on Open Settings on the page and set Base URL to `http://localhost:8080/`. Any changes to your JSON will now be reflected in the extension and developer app.
-6. Update the inputs with the right path to your integration `localhost:8080/{platform_name}/{provider_name}.json`
+4. Test your integration by going to the [Peer Developer Portal](https://developer.peer.xyz/)
+5. Click on Open Settings on the page. This will open the PeerAuth extension, set Providers Base URL to `http://localhost:8080/` (Note the "/" at the end, it is required). Any changes to your JSON will now be reflected in the extension and developer app
+6. In the Peer Developer Portal, update the inputs with the right path to your integration: "ActionType" refers to platform_name (i.e.: Zelle, Venmo...) and Payment Platform refers to provider_name (i.e.: Chase, Truist ...)
 7. Click Authenticate to extract metadata
 8. If successful, proceed to Prove a specific transaction
 
@@ -535,8 +535,8 @@ Use regular expressions for pattern matching:
 - Consider user experience when deciding tab behavior
 
 ### Common Issues
-- **Authenticate does not open desired auth link**: Check the Base URL you have set in the extension. Ensure you are running the server which is hosted in port 8080
-- **Authenticated into your payment platform but not redirected back to developer.zkp2p.xyz**: There is an issue with the urlRegex for metadata extraction. Double check your regex is correct
+- **Authenticate does not open desired auth link**: Check the Base URL you have set in the extension. Ensure you are running the server which is hosted in port 8080. Check your template json file does not have any syntax errors.
+- **Authenticated into your payment platform but not redirected back to developer.peer.xyz**: There is an issue with the urlRegex for metadata extraction. Double check your regex is correct
 - **Metadata returned to app, but Prove fails**: There is an issue with the response redactions or headers for the server call. If error is JSON path not found or regex not found then check your response redactions parameters. If it returns a error that is not 200, the server has rejected your request, so there is an issue with your headers, request body.
 - **Parameters not extracted correctly**: Check the `source` field in your `paramSelectors`. By default, parameters are extracted from responseBody. If your parameter is in the URL, headers, or request body, you must specify the correct source.
 


### PR DESCRIPTION
## Overview
Based on my personal experience adding a provider template, I added the info I would like to have read on the README of this repo. @richardliang helped me get unblocked by giving me these fixes and warnings during the process.

I also pushed some rebranding changes on a separate commit. Changes include:
1. "ZKP2P PeerAuth" to "Peer Extension"
2. "ZKP2P" for "Peer"
3. "developer.zkp2p.xyz" for "Peer Developer Portal"

I can revert this commit if unwanted .