### PR TITLE
fix(paypal): Fix PayPal Business amount parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.10",
+  "version": "7.8.11",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/paypal/transfer_business_paypal.json
+++ b/paypal/transfer_business_paypal.json
@@ -57,11 +57,11 @@
     },
     {
       "type": "regex",
-      "value": "\\$(?<amt>[0-9.]+)"
+      "value": "\"grossAmt\":\"[^\"]*?(?<amt>[0-9][0-9,]*(?:\\.[0-9]+)?)"
     },
     {
       "type": "regex",
-      "value": "\"grossAmt\":\"[^\\\"]*[0-9.]+[^A-Z]*(?<curr>[A-Z]+)"
+      "value": "\"grossAmt\":\"[^\"]*[0-9.]+[^A-Z]*(?<curr>[A-Z]+)"
     },
     {
       "type": "regex",


### PR DESCRIPTION
## Summary
- Tighten the PayPal Business amount matcher to extract the numeric value from `grossAmt` instead of the first dollar fragment.
- Keep currency extraction tied to the same `grossAmt` field.
- Bump `@zkp2p/providers` to `7.8.11` for the template change.

## Testing
- Validated both JSON files parse cleanly.
- Verified the updated regex extracts amounts like `$0.72 USD` and `AU$1,234.56 AUD` correctly in local checks.