### PR TITLE
Fix PayPal business date regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.11",
+  "version": "7.8.12",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/paypal/transfer_business_paypal.json
+++ b/paypal/transfer_business_paypal.json
@@ -69,7 +69,7 @@
     },
     {
       "type": "regex",
-      "value": "(?<date>[A-Z][a-z]+ [0-9]{1,2}, [0-9]{4}[^\"]*)"
+      "value": "\"TDHeader\"\\s*:\\s*\\{[^}]*\"date\"\\s*:\\s*\"(?<date>[^\"]+)\""
     }
   ],
   "responseRedactions": [

--- a/paypal/transfer_business_paypal.json
+++ b/paypal/transfer_business_paypal.json
@@ -69,7 +69,7 @@
     },
     {
       "type": "regex",
-      "value": "\"TDHeader\"\\s*:\\s*\\{[^}]*\"date\"\\s*:\\s*\"(?<date>[^\"]+)\""
+      "value": "\"date\"\\s*:\\s*\"(?<date>[^\"]+)\""
     }
   ],
   "responseRedactions": [


### PR DESCRIPTION
This fixes a PayPal business transfer proof failure where proof generation could fail with `Invalid receipt. Regex "(?<date>[A-Z][a-z]+ [0-9]{1,2}, [0-9]{4}[^"]*)" didn't match`.

The provider was proving the PayPal business transaction detail response, but the date response match assumed PayPal would always render the date as an English display date like `April 24, 2026`. When PayPal returns the same date value in another string format, such as an ISO timestamp, abbreviated display string, or numeric date, the response match fails even though the transaction detail response still contains a usable date field. Users then see a generic proof generation failure after selecting the payment.

The root cause was that the date regex encoded PayPal's old display-date format instead of extracting the JSON `date` field generically. This PR changes the response match to capture any JSON string `date` field with the existing `date` named capture, preserving the proof parameter while accepting PayPal's current date string format.

This also bumps `@zkp2p/providers` from `7.8.11` to `7.8.12` for the provider template release.

Validation performed:
- Parsed every JSON provider template in the repo with Node.
- Verified the PayPal business date response match captures old display dates, abbreviated display dates, ISO timestamps, and numeric date strings.
- Verified `package.json` reports version `7.8.12`.
