### PR TITLE
feat(paypal): optional note capture for shared nullifier (7.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.9.0-rc.0",
+  "version": "7.9.0",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.8.12",
+  "version": "7.9.0-rc.0",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/paypal/transfer_paypal.json
+++ b/paypal/transfer_paypal.json
@@ -73,6 +73,10 @@
     {
       "type": "regex",
       "value": "\"primitiveTimeCreated\":\"(?<date>[^\"]+)\""
+    },
+    {
+      "type": "regex",
+      "value": "(?:(?=.*\"notesInfo\":\\{[^}]*\"note\":\"(?<note>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\")|)"
     }
   ],
   "responseRedactions": [
@@ -98,6 +102,10 @@
     },
     {
       "jsonPath": "$.data.primitiveTimeCreated",
+      "xPath": ""
+    },
+    {
+      "jsonPath": "$.data.notesInfo.note",
       "xPath": ""
     }
   ],


### PR DESCRIPTION
## Summary

Add an optional `note` named-capture to the PayPal personal transfer template plus a matching `responseRedactions` jsonPath for `$.data.notesInfo.note`, so PayPal buyer-side Reclaim proofs can surface the sender-supplied memo.

The regex uses an empty alternative (`(?:(?=...)|)`) so proofs without a note still validate. When a note is present, it's captured into the `note` named group; when absent, the regex matches the empty alternative and the consumer treats the value as empty.

## Why

The attestation-service is rolling out a shared-nullifier scheme for PayPal that requires the memo to participate in a cross-flow composite preimage tying buyer-side (Reclaim TLS proof) and seller-side (DKIM-signed Gmail receipt) settlements to the same on-chain nullifier. Without this capture, the buyer flow can't surface the memo, breaks byte-equality with the seller flow, and double-spends become possible.

Companion PR: zkp2p/attestation-service#128

## Version

Bumped to `7.9.0`. (Earlier `7.9.0-rc.0` was validated end-to-end against attestation-service; promoting to final.)

## Validation

- Computed hash of bumped template via `@reclaimprotocol/attestor-core::hashProviderParams` matches the hash attestation-service has already registered in `PAYPAL_PROVIDER_HASHES.sharedNullifierPersonal`:
  `0x594596d04b959d383e809869ce0f513e2221473b17d869abefad07c4e1b23fbd`
- No changes to other templates. Existing personal/business proof hashes for non-PayPal flows are unaffected.

## Publish

After merge, publish to npm:
```bash
npm publish
```