### PR TITLE
fix(paypal): tolerate missing notesInfo (7.9.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/providers",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "description": "Provider JSON templates for ZKP2P",
   "scripts": {
     "start": "node index.js"

--- a/paypal/transfer_paypal.json
+++ b/paypal/transfer_paypal.json
@@ -76,7 +76,7 @@
     },
     {
       "type": "regex",
-      "value": "(?:(?=.*\"notesInfo\":\\{[^}]*\"note\":\"(?<note>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\")|)"
+      "value": "[\\s\\S]*?\"notesInfo\"\\s*:\\s*\\{[^}]*\"note\"\\s*:\\s*\"(?<note>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|"
     }
   ],
   "responseRedactions": [
@@ -105,8 +105,7 @@
       "xPath": ""
     },
     {
-      "jsonPath": "$.data.notesInfo.note",
-      "xPath": ""
+      "regex": "\"notesInfo\"\\s*:\\s*\\{[^}]*\"note\"\\s*:\\s*\"(?<note>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|\\}\\s*$"
     }
   ],
   "mobile": {


### PR DESCRIPTION
The 7.9.0 `paypal/transfer_paypal.json` has two incompatibilities with the deployed Reclaim attestor + browser path:

1. Mandatory jsonPath redaction `$.data.notesInfo.note` throws `jsonPath not found` for memo-less PayPal transfers (PayPal omits the entire `notesInfo` object when no memo is attached).
2. The note responseMatch uses a `(?=...)` lookahead which RE2 rejects with `invalid perl operator: (?=`.

This PR replaces both with RE2-compatible patterns that keep the note capture optional. New PayPal personal provider hash: `0xb52665e39be9635295c4e5eef4e6070b1e215c064db4e23826690df0fe8cf4cf`. Business hash unchanged.

Validated end-to-end on staging through 7.9.1-rc.0 / 7.9.1-rc.1; this is the stable 7.9.1 cut.

Bumps to `7.9.1` (publishes to `@latest` on merge to main).

## Test plan
- [x] memo-less PayPal transfer end-to-end (`fileboin@gmail.com`, £3.10 GBP, no note) — attestor signs cleanly
- [x] memo-bearing PayPal transfer end-to-end (`galinaglis@hotmail.com`, €0.08, note "orange fruit") — attestor signs cleanly with note captured